### PR TITLE
Not everyone has afxres.h

### DIFF
--- a/Video.rc
+++ b/Video.rc
@@ -7,7 +7,9 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+//#include "afxres.h"
+#include "WinResrc.h"
+#define IDC_STATIC  -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS


### PR DESCRIPTION
If you didn't check Microsoft Foundation Classes for C++ while installing Visual Studio, you didn't get this file.